### PR TITLE
gitignore設定を追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+/vendor/bundle/
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
+# Ignore RubyMine
+/.idea/
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*


### PR DESCRIPTION
gitignoreを微調整します。

* bundle install --path vendor/bundleのインストールパスを除外する
* RubyMineが出力する設定ディレクトリは無視する
