### PR TITLE
「確認用ポップアップを表示する」チェックボックスを追加

### DIFF
--- a/app/views/messages/create.html.erb
+++ b/app/views/messages/create.html.erb
@@ -11,11 +11,11 @@
   </template>
   <button @click.prevent="addMessageButton">追加する</button>
 
-  <%= f.form_group(:form_type, label: { text: 'select message form type' }) do %>
-    <%= f.radio_button :form_type, 1, label: "Single button", checked: true %>
-    <%= f.radio_button :form_type, 2, label: "Multi button", checked: false %>
-    <%= f.radio_button :form_type, 3, label: "Toggle button", checked: false %>
-  <% end %>
+  <p>
+    <%= check_box_tag :require_confirm, '確認用ポップアップを表示する' %>
+    <%= label_tag :require_confirm, '確認用ポップアップを表示する' %>
+  </p>
+
   <%= f.datetime_select :due_at, label: { text: '対応期限' }, class: 'form-control', use_month_numbers: true, minute_step: 10 %>
 
   <%= f.submit('Create') %>

--- a/app/views/messages/create.html.erb
+++ b/app/views/messages/create.html.erb
@@ -17,12 +17,7 @@
     <%= f.radio_button :form_type, 3, label: "Toggle button", checked: false %>
   <% end %>
   <%= f.datetime_select :due_at, label: { text: '対応期限' }, class: 'form-control', use_month_numbers: true, minute_step: 10 %>
-  <%= f.form_group(:remind_times, label: { text: 'select remind times' }) do %>
-    <%= f.check_box :remind_times, value: 600, label: "10 min", checked: false %>
-    <%= f.check_box :remind_times, value: 3600, label: "1 hour", checked: false %>
-    <%= f.check_box :remind_times, value: 86400, label: "1 day", checked: false %>
-    <%= f.check_box :remind_times, value: 604800, label: "1 week", checked: false %>
-  <% end %>
+
   <%= f.submit('Create') %>
 <% end %>
 </div>


### PR DESCRIPTION
## このPRですること
https://github.com/honeymoon-answer/answer/pull/10#discussion_r130863283 で同意頂いた件の対応です。

![image](https://user-images.githubusercontent.com/1726225/29119816-94ecd370-7d42-11e7-9030-ee4dbda23a83.png)

このチェックボックスを入れると

![](https://user-images.githubusercontent.com/1726225/28873692-b04e8286-77c9-11e7-8e1e-07c2c5985654.png)

を表示してボタンの押し間違いを防止します。