### PR TITLE
[WIP] 依頼登録用エントリポイント POST /api/v1/messagesを実装する

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -11,19 +11,13 @@ class Api::V1::MessagesController < ApplicationController
     Message.transaction do
       message = Message.new(message_attributes)
       message.user_id = 1 # TODO: Pass the user id parameter from payload user id in JWT.
-      message.save
-
       message_buttons_attributes[:message_buttons].each do |m|
-        message_button = MessageButton.new(m)
-        message_button.message_id = message.id
-        message_button.save
+        message.message_buttons << MessageButton.new(m)
       end
-
       mentions_attributes[:mentions].each do |m|
-        mention = Mention.new(m)
-        mention.message_id = message.id
-        mention.save
+        message.mentions << Mention.new(m)
       end
+      message.save!
     end
 
     # TODO: Send Message Button to mention users by Slack DM.

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -4,6 +4,12 @@ class Api::V1::MessagesController < ApplicationController
   end
 
   def create
+    attributes = params.permit(:message, :require_confirm, :due_at)
+
+    message = Message.new(attributes)
+    message.user_id = 1
+    message.save
+
     head :created
   end
 end

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::MessagesController < ApplicationController
   def create
     message_attributes = params.permit(:message, :require_confirm, :due_at)
     message_buttons_attributes = params.permit(message_buttons: [:text])
-    mentions_attributes = params.permit(mentions: [:slack_id])
+    mentions_attributes = params.permit(mentions: [:slack_id, :name, :profile_picture_url])
 
     Message.transaction do
       message = Message.new(message_attributes)

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::MessagesController < ApplicationController
   def index
     @messages = Message.where("user_id = ?", 1)
   end
+
+  def create
+    head :created
+  end
 end

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::MessagesController < ApplicationController
 
     Message.transaction do
       message = Message.new(message_attributes)
-      message.user_id = 1
+      message.user_id = 1 # TODO: Pass the user id parameter from payload user id in JWT.
       message.save
 
       message_buttons_attributes[:message_buttons].each do |m|
@@ -25,6 +25,8 @@ class Api::V1::MessagesController < ApplicationController
         mention.save
       end
     end
+
+    # TODO: Send Message Button to mention users by Slack DM.
 
     head :created
   end

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -8,14 +8,18 @@ class Api::V1::MessagesController < ApplicationController
     message_buttons_params = params.permit(message_buttons: [:text])
     mentions_params = params.permit(mentions: [:slack_id, :name, :profile_picture_url])
 
+    message = Message.new(message_params)
+    message.user_id = 1 # TODO: Pass the user id parameter from payload user id in JWT.
+
+    message.message_buttons = message_buttons_params[:message_buttons].map {|m| MessageButton.new(m) }
+    message.mentions = mentions_params[:mentions].map {|m| Mention.new(m) }
+
     Message.transaction do
-      message = Message.new(message_params)
-      message.user_id = 1 # TODO: Pass the user id parameter from payload user id in JWT.
-
-      message.message_buttons = message_buttons_params[:message_buttons].map {|m| MessageButton.new(m) }
-      message.mentions = mentions_params[:mentions].map {|m| Mention.new(m) }
-
-      message.save!
+      begin
+        message.save!
+      rescue e
+        Rails.logger.error e.inspect
+      end
     end
 
     # TODO: Send Message Button to mention users by Slack DM.

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -8,20 +8,22 @@ class Api::V1::MessagesController < ApplicationController
     message_buttons_attributes = params.permit(message_buttons: [:text])
     mentions_attributes = params.permit(mentions: [:slack_id])
 
-    message = Message.new(message_attributes)
-    message.user_id = 1
-    message.save
+    Message.transaction do
+      message = Message.new(message_attributes)
+      message.user_id = 1
+      message.save
 
-    message_buttons_attributes[:message_buttons].each do |m|
-      message_button = MessageButton.new(m)
-      message_button.message_id = message.id
-      message_button.save
-    end
+      message_buttons_attributes[:message_buttons].each do |m|
+        message_button = MessageButton.new(m)
+        message_button.message_id = message.id
+        message_button.save
+      end
 
-    mentions_attributes[:mentions].each do |m|
-      mention = Mention.new(m)
-      mention.message_id = message.id
-      mention.save
+      mentions_attributes[:mentions].each do |m|
+        mention = Mention.new(m)
+        mention.message_id = message.id
+        mention.save
+      end
     end
 
     head :created

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -11,12 +11,10 @@ class Api::V1::MessagesController < ApplicationController
     Message.transaction do
       message = Message.new(message_params)
       message.user_id = 1 # TODO: Pass the user id parameter from payload user id in JWT.
-      message_buttons_params[:message_buttons].each do |m|
-        message.message_buttons << MessageButton.new(m)
-      end
-      mentions_params[:mentions].each do |m|
-        message.mentions << Mention.new(m)
-      end
+
+      message.message_buttons = message_buttons_params[:message_buttons].map {|m| MessageButton.new(m) }
+      message.mentions = mentions_params[:mentions].map {|m| Mention.new(m) }
+
       message.save!
     end
 

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -4,11 +4,18 @@ class Api::V1::MessagesController < ApplicationController
   end
 
   def create
-    attributes = params.permit(:message, :require_confirm, :due_at)
+    message_attributes = params.permit(:message, :require_confirm, :due_at)
+    message_buttons_attributes = params.permit(message_buttons: [:text])
 
-    message = Message.new(attributes)
+    message = Message.new(message_attributes)
     message.user_id = 1
     message.save
+
+    message_buttons_attributes[:message_buttons].each do |m|
+      message_button = MessageButton.new(m)
+      message_button.message_id = message.id
+      message_button.save
+    end
 
     head :created
   end

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -4,17 +4,17 @@ class Api::V1::MessagesController < ApplicationController
   end
 
   def create
-    message_attributes = params.permit(:message, :require_confirm, :due_at)
-    message_buttons_attributes = params.permit(message_buttons: [:text])
-    mentions_attributes = params.permit(mentions: [:slack_id, :name, :profile_picture_url])
+    message_params = params.permit(:message, :require_confirm, :due_at)
+    message_buttons_params = params.permit(message_buttons: [:text])
+    mentions_params = params.permit(mentions: [:slack_id, :name, :profile_picture_url])
 
     Message.transaction do
-      message = Message.new(message_attributes)
+      message = Message.new(message_params)
       message.user_id = 1 # TODO: Pass the user id parameter from payload user id in JWT.
-      message_buttons_attributes[:message_buttons].each do |m|
+      message_buttons_params[:message_buttons].each do |m|
         message.message_buttons << MessageButton.new(m)
       end
-      mentions_attributes[:mentions].each do |m|
+      mentions_params[:mentions].each do |m|
         message.mentions << Mention.new(m)
       end
       message.save!

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::MessagesController < ApplicationController
   def create
     message_attributes = params.permit(:message, :require_confirm, :due_at)
     message_buttons_attributes = params.permit(message_buttons: [:text])
+    mentions_attributes = params.permit(mentions: [:slack_id])
 
     message = Message.new(message_attributes)
     message.user_id = 1
@@ -15,6 +16,12 @@ class Api::V1::MessagesController < ApplicationController
       message_button = MessageButton.new(m)
       message_button.message_id = message.id
       message_button.save
+    end
+
+    mentions_attributes[:mentions].each do |m|
+      mention = Mention.new(m)
+      mention.message_id = message.id
+      mention.save
     end
 
     head :created

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   namespace :api, {format: 'json'} do
     namespace :v1 do
-      resources :messages, only: :index
+      resources :messages, only: [:index, :create]
     end
   end
 end

--- a/db/migrate/20170815074423_add_columns_to_mentions.rb
+++ b/db/migrate/20170815074423_add_columns_to_mentions.rb
@@ -1,0 +1,6 @@
+class AddColumnsToMentions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :mentions, :name, :string, comment: 'Slack user name'
+    add_column :mentions, :profile_picture_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170812081211) do
+ActiveRecord::Schema.define(version: 20170815074423) do
 
   create_table "mentions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "message_id"
     t.string "slack_id", comment: "Mentioned user's slack user ID"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name", comment: "Slack user name"
+    t.string "profile_picture_url"
     t.index ["message_id"], name: "index_mentions_on_message_id"
   end
 

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Messages", type: :request do
                                      { text: 'button01' },
                                    ],
                                    mentions: [
-                                     { slack_id: 'UHOGEHOGE' }
+                                     { slack_id: 'UHOGEHOGE', name: 'fuga', profile_picture_url: 'http://hoge.com/fuga.jpg' }
                                    ]
                                  }
 
@@ -58,6 +58,8 @@ RSpec.describe "Messages", type: :request do
       expect(@message[:due_at]).to eq '2017-08-15 10:00:00'
       expect(@message_buttons[0][:text]).to eq 'button01'
       expect(@mentions[0][:slack_id]).to eq 'UHOGEHOGE'
+      expect(@mentions[0][:name]).to eq 'fuga'
+      expect(@mentions[0][:profile_picture_url]).to eq 'http://hoge.com/fuga.jpg'
     end
   end
 end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -28,12 +28,21 @@ RSpec.describe "Messages", type: :request do
 
   describe "POST /api/v1/messages" do
     before do
-      post api_v1_messages_path
+      create(:user, id: 1)
+      post api_v1_messages_path, params: { message: 'hoge', require_confirm: 0, due_at: '2017-08-15 10:00:00' }
+
+      @message = Message.first
     end
 
     it 'response 201' do
       expect(response).to be_success
       expect(response.status).to eq 201
+    end
+
+    it 'check db registration' do
+      expect(@message[:message]).to eq 'hoge'
+      expect(@message[:require_confirm]).to eq false
+      expect(@message[:due_at]).to eq '2017-08-15 10:00:00'
     end
   end
 end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Messages", type: :request do
 
   describe "POST /api/v1/messages" do
     before do
-      post '/api/v1/messages'
+      post api_v1_messages_path
     end
 
     it 'response 201' do

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -25,4 +25,15 @@ RSpec.describe "Messages", type: :request do
       expect(m['require_confirm']).to eq @message.require_confirm
     end
   end
+
+  describe "POST /api/v1/messages" do
+    before do
+      post '/api/v1/messages'
+    end
+
+    it 'response 201' do
+      expect(response).to be_success
+      expect(response.status).to eq 201
+    end
+  end
 end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -36,11 +36,15 @@ RSpec.describe "Messages", type: :request do
                                    due_at: '2017-08-15 10:00:00',
                                    message_buttons: [
                                      { text: 'button01' },
+                                   ],
+                                   mentions: [
+                                     { slack_id: 'UHOGEHOGE' }
                                    ]
                                  }
 
       @message = Message.first
       @message_buttons = MessageButton.where('message_id = ?', @message.id)
+      @mentions = Mention.where('message_id = ?', @message.id)
     end
 
     it 'response 201' do
@@ -53,6 +57,7 @@ RSpec.describe "Messages", type: :request do
       expect(@message[:require_confirm]).to eq false
       expect(@message[:due_at]).to eq '2017-08-15 10:00:00'
       expect(@message_buttons[0][:text]).to eq 'button01'
+      expect(@mentions[0][:slack_id]).to eq 'UHOGEHOGE'
     end
   end
 end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -29,9 +29,18 @@ RSpec.describe "Messages", type: :request do
   describe "POST /api/v1/messages" do
     before do
       create(:user, id: 1)
-      post api_v1_messages_path, params: { message: 'hoge', require_confirm: 0, due_at: '2017-08-15 10:00:00' }
+      post api_v1_messages_path, params:
+                                 {
+                                   message: 'hoge',
+                                   require_confirm: 0,
+                                   due_at: '2017-08-15 10:00:00',
+                                   message_buttons: [
+                                     { text: 'button01' },
+                                   ]
+                                 }
 
       @message = Message.first
+      @message_buttons = MessageButton.where('message_id = ?', @message.id)
     end
 
     it 'response 201' do
@@ -43,6 +52,7 @@ RSpec.describe "Messages", type: :request do
       expect(@message[:message]).to eq 'hoge'
       expect(@message[:require_confirm]).to eq false
       expect(@message[:due_at]).to eq '2017-08-15 10:00:00'
+      expect(@message_buttons[0][:text]).to eq 'button01'
     end
   end
 end


### PR DESCRIPTION
## このPRですること
以下JSONが送信されてくることを前提で、依頼登録用エントリポイント `POST /api/v1/messages`を追加する。まずはDB登録処理のみを実装する。

```json
// Request Body
{
    "message": "hoge",
    "require_confirm": 0,
    "due_at": "2017-08-15 10:00:00",
    "message_buttons": [
        { "text": "9/1" },
        { "text": "9/2" }
    ],
    "mentions": [
        { "slack_id": "UHOGEHOGE", "name": "takumakume" },
        { "slack_id": "UHOGEHOGE", "name": "hypermkt" }
    ]
}
```

### しないこと
* Slack APIの呼び出し。