### PR TITLE
アプリから送ったDMの特定に必要な情報を保持しておく

### DIFF
--- a/app/workers/slack_message_worker.rb
+++ b/app/workers/slack_message_worker.rb
@@ -22,14 +22,7 @@ class SlackMessageWorker
 
     mention.channel = response.channel
     mention.ts= response.ts
-
-    Mention.transaction do
-      begin
-        mention.save!
-      rescue => e
-        Rails.logger.error e.inspect
-      end
-    end
+    mention.save!
 
     response
   end

--- a/app/workers/slack_message_worker.rb
+++ b/app/workers/slack_message_worker.rb
@@ -6,8 +6,9 @@ class SlackMessageWorker
 
     mention = Mention.find(mention_id)
     message = mention.message
+
     begin
-      message_button.post(
+      response = message_button.post(
         {
           callback_id: message.callback_id,
           channel: mention.slack_id,
@@ -18,5 +19,18 @@ class SlackMessageWorker
     rescue => e
       Rails.logger.error e.inspect
     end
+
+    mention.channel = response.channel
+    mention.ts= response.ts
+
+    Mention.transaction do
+      begin
+        mention.save!
+      rescue => e
+        Rails.logger.error e.inspect
+      end
+    end
+
+    response
   end
 end

--- a/db/migrate/20170824122804_add_ts_to_mention.rb
+++ b/db/migrate/20170824122804_add_ts_to_mention.rb
@@ -1,0 +1,6 @@
+class AddTsToMention < ActiveRecord::Migration[5.1]
+  def change
+    add_column :mentions, :channel, :string, comment: 'ts to determine sended DM'
+    add_column :mentions, :ts, :string, comment: 'channel to determine sended DM'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170820024441) do
+ActiveRecord::Schema.define(version: 20170824122804) do
 
   create_table "mentions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "message_id"
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(version: 20170820024441) do
     t.datetime "updated_at", null: false
     t.string "name", comment: "Slack user name"
     t.string "profile_picture_url"
+    t.string "channel", comment: "ts to determine sended DM"
+    t.string "ts", comment: "channel to determine sended DM"
     t.index ["message_id"], name: "index_mentions_on_message_id"
   end
 

--- a/spec/workers/slack_message_worker_spec.rb
+++ b/spec/workers/slack_message_worker_spec.rb
@@ -35,5 +35,12 @@ describe SlackMessageWorker  do
       expect(res['message']['type']).to eq 'message'
       expect(res['message']['subtype']).to eq 'bot_message'
     end
+
+    it 'mention data updated' do
+      subject.perform(@mention_id)
+      m = Mention.find(@mention_id)
+      expect(m.channel).to eq 'DXXXXXXXX'
+      expect(m.ts).to eq '1503499924.000735'
+    end
   end
 end


### PR DESCRIPTION
ref #2 

リマインダの仕組みとして

 * 同じ設問を再度DMする
 * そのタイミングで過去に送ったDMはアップデートして回答出来ないようにしておく

としたい。

そのため、送ったDMの特定が出来るようにする。